### PR TITLE
Add adjustable circle radius for the mask with default value of 300px

### DIFF
--- a/content.js
+++ b/content.js
@@ -22,8 +22,9 @@ function enableMask() {
 
     document.addEventListener('mousemove', handleMouseMove);
 
-    chrome.storage.sync.get({ maskStrength: 0.8 }, (data) => {
+    chrome.storage.sync.get({ maskStrength: 0.8, maskRadius: 300 }, (data) => {
       mask.style.setProperty('--mask-opacity', data.maskStrength);
+      mask.style.setProperty('--mask-radius', `${data.maskRadius}px`);
     });
   }
 }

--- a/options.html
+++ b/options.html
@@ -33,7 +33,7 @@
     label {
       display: block;
       font-weight: bold;
-      margin-bottom: 8px;
+      margin-bottom: 12px;
       color: #e0e0e0;
     }
     input {
@@ -70,6 +70,8 @@
     <h1>Just Enough Light</h1>
     <label for="mask-strength">Mask Strength (0.0 - 1.0):</label>
     <input type="number" id="mask-strength" min="0" max="1" step="0.1">
+    <label for="mask-radius">Mask Radius (in pixels):</label>
+    <input type="number" id="mask-radius" min="100" max="1000" step="10">
     <button id="save-button">Save</button>
   </div>
   <script src="options.js"></script>

--- a/options.js
+++ b/options.js
@@ -1,21 +1,25 @@
 document.addEventListener('DOMContentLoaded', () => {
   const maskStrengthInput = document.getElementById('mask-strength');
+  const maskRadiusInput = document.getElementById('mask-radius');
   const saveButton = document.getElementById('save-button');
 
   // Load current settings
-  chrome.storage.sync.get({ maskStrength: 0.8 }, (data) => {
+  chrome.storage.sync.get({ maskStrength: 0.8, maskRadius: 300 }, (data) => {
     maskStrengthInput.value = data.maskStrength;
+    maskRadiusInput.value = data.maskRadius;
   });
 
   // Save new settings
   saveButton.addEventListener('click', () => {
     const maskStrength = parseFloat(maskStrengthInput.value);
-    if (maskStrength >= 0 && maskStrength <= 1) {
-      chrome.storage.sync.set({ maskStrength }, () => {
+    const maskRadius = parseInt(maskRadiusInput.value, 10);
+
+    if ((maskStrength >= 0 && maskStrength <= 1) && (maskRadius >= 100 && maskRadius <= 1000)) {
+      chrome.storage.sync.set({ maskStrength, maskRadius }, () => {
         alert('Settings saved!');
       });
     } else {
-      alert('Please enter a value between 0.0 and 1.0');
+      alert('Please enter valid values: Mask Strength (0.0 - 1.0), Mask Radius (100 - 1000px)');
     }
   });
 });

--- a/styles.css
+++ b/styles.css
@@ -5,7 +5,7 @@
   width: 100%;
   height: 100%;
   pointer-events: none;
-  background: radial-gradient(circle 300px at var(--cursor-x, 50%) var(--cursor-y, 50%), rgba(0, 0, 0, 0) 300px, rgba(0, 0, 0, var(--mask-opacity, 0.8)) 320px);
+  background: radial-gradient(circle var(--mask-radius, 300px) at var(--cursor-x, 50%) var(--cursor-y, 50%), rgba(0, 0, 0, 0) var(--mask-radius, 300px), rgba(0, 0, 0, var(--mask-opacity, 0.8)) calc(var(--mask-radius, 300px) + 20px));
   z-index: 2147483647;
   mix-blend-mode: multiply;
 }


### PR DESCRIPTION
- Updated content script to dynamically set mask radius based on stored value.
- Added mask radius input field to the options page for user customization.
- Extended storage settings to include `maskRadius` with a default of 300px.
- Adjusted styles and mask rendering logic to support configurable radius.